### PR TITLE
Specify npm registry url when installing packages in generate workflow

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: '18'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --registry=https://registry.npmjs.org/
 
       - name: Check for 'autorelease' keyword in commit messages
         run: |

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@seamapi:registry=https://registry.npmjs.org/


### PR DESCRIPTION
Adding .npmrc file with the specified url didn't work. Decided to specify it inline in the workflow itself.